### PR TITLE
Use static.crates.io for crates.io fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,26 @@ jobs:
       - name: build examples
         run: |
           if [[ $RUNNER_OS == Linux ]]; then
-          nix build ./examples/1-hello-world#
-          nix build ./examples/2-bigger-project#
-          nix build ./examples/3-cross-compiling#
-          nix build ./examples/4-independent-packaging#
+          nix build ./examples/1-hello-world# \
+            --no-write-lock-file
+          nix build ./examples/2-bigger-project# \
+            --no-write-lock-file
+          nix build ./examples/3-cross-compiling# \
+            --no-write-lock-file
+          nix build ./examples/4-independent-packaging# \
+            --no-write-lock-file
           else
           nix build ./examples/1-hello-world# \
+            --no-write-lock-file \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/2-bigger-project# \
+            --no-write-lock-file \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           # nix build ./examples/3-cross-compiling#
+          #   --no-write-lock-file \
           #   --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/4-independent-packaging# \
+            --no-write-lock-file \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3.2.0
-      - uses: cachix/install-nix-action@v23
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             log-lines = 200
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v17
         with:
           name: cargo2nix-gh
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,28 +58,19 @@ jobs:
 
       - name: build examples
         run: |
-          cargo2nix_input="path:$GITHUB_WORKSPACE"
           if [[ $RUNNER_OS == Linux ]]; then
-          nix build ./examples/1-hello-world# \
-            --override-input cargo2nix "$cargo2nix_input"
-          nix build ./examples/2-bigger-project# \
-            --override-input cargo2nix "$cargo2nix_input"
-          nix build ./examples/3-cross-compiling# \
-            --override-input cargo2nix "$cargo2nix_input"
-          nix build ./examples/4-independent-packaging# \
-            --override-input cargo2nix "$cargo2nix_input"
+          nix build ./examples/1-hello-world#
+          nix build ./examples/2-bigger-project#
+          nix build ./examples/3-cross-compiling#
+          nix build ./examples/4-independent-packaging#
           else
           nix build ./examples/1-hello-world# \
-            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/2-bigger-project# \
-            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           # nix build ./examples/3-cross-compiling#
-          #   --override-input cargo2nix "$cargo2nix_input" \
           #   --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/4-independent-packaging# \
-            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,28 @@ jobs:
 
       - name: build examples
         run: |
+          cargo2nix_input="path:$GITHUB_WORKSPACE"
           if [[ $RUNNER_OS == Linux ]]; then
           nix build ./examples/1-hello-world# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA
+            --override-input cargo2nix "$cargo2nix_input"
           nix build ./examples/2-bigger-project# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA
+            --override-input cargo2nix "$cargo2nix_input"
           nix build ./examples/3-cross-compiling# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA
+            --override-input cargo2nix "$cargo2nix_input"
           nix build ./examples/4-independent-packaging# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA
+            --override-input cargo2nix "$cargo2nix_input"
           else
           nix build ./examples/1-hello-world# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA \
+            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/2-bigger-project# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA \
+            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           # nix build ./examples/3-cross-compiling#
-          #   --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA \
+          #   --override-input cargo2nix "$cargo2nix_input" \
           #   --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           nix build ./examples/4-independent-packaging# \
-            --override-input cargo2nix github:cargo2nix/cargo2nix?rev=$GITHUB_SHA \
+            --override-input cargo2nix "$cargo2nix_input" \
             --override-input nixpkgs github:nixos/nixpkgs/nixpkgs-23.11-darwin
           fi
 

--- a/examples/3-cross-compiling/README.md
+++ b/examples/3-cross-compiling/README.md
@@ -45,8 +45,8 @@ nix-repl> lib.systems.examples.wasi32
 { config = "wasm32-unknown-wasi"; useLLVM = true; }
 ```
 
-This example uses `wasm32-wasi` below because Rust 1.75 provides its WASI
-standard library component under that target name.
+This example sets cargo2nix's Rust target to `wasm32-wasi` below because Rust
+1.75 provides its WASI standard library component under that target name.
 
 Most crossSystem values are simple like this.  Others make more specific
 changes.  Many only set the `config` attribute to a host triple + abi like
@@ -203,7 +203,7 @@ Create a new file called [`flake.nix`]:
           # nixpkgs, set this target
           # target = "aarch64-unknown-linux-gnu";
           # target = "x86_64-unknown-linux-musl";
-          # target = "wasm32-wasi";
+          target = "wasm32-wasi";
         };
 
       in rec {

--- a/examples/3-cross-compiling/README.md
+++ b/examples/3-cross-compiling/README.md
@@ -187,6 +187,7 @@ Create a new file called [`flake.nix`]:
 
           crossSystem = {
             config = "wasm32-wasi";
+            rustc.config = "wasm32-wasi";
             # Nixpkgs currently only supports LLVM lld linker for wasm32-wasi.
             useLLVM = true;
           };

--- a/examples/3-cross-compiling/README.md
+++ b/examples/3-cross-compiling/README.md
@@ -45,6 +45,9 @@ nix-repl> lib.systems.examples.wasi32
 { config = "wasm32-unknown-wasi"; useLLVM = true; }
 ```
 
+This example uses `wasm32-wasi` below because Rust 1.75 provides its WASI
+standard library component under that target name.
+
 Most crossSystem values are simple like this.  Others make more specific
 changes.  Many only set the `config` attribute to a host triple + abi like
 `x86_64-unknown-linux-musl`.
@@ -183,7 +186,7 @@ Create a new file called [`flake.nix`]:
           # };
 
           crossSystem = {
-            config = "wasm32-unknown-wasi";
+            config = "wasm32-wasi";
             # Nixpkgs currently only supports LLVM lld linker for wasm32-wasi.
             useLLVM = true;
           };

--- a/examples/3-cross-compiling/flake.nix
+++ b/examples/3-cross-compiling/flake.nix
@@ -33,6 +33,7 @@
 
           crossSystem = {
             config = "wasm32-wasi";
+            rustc.config = "wasm32-wasi";
             # Nixpkgs currently only supports LLVM lld linker for wasm32-wasi.
             useLLVM = true;
           };

--- a/examples/3-cross-compiling/flake.nix
+++ b/examples/3-cross-compiling/flake.nix
@@ -32,7 +32,7 @@
           # };
 
           crossSystem = {
-            config = "wasm32-unknown-wasi";
+            config = "wasm32-wasi";
             # Nixpkgs currently only supports LLVM lld linker for wasm32-wasi.
             useLLVM = true;
           };

--- a/examples/3-cross-compiling/flake.nix
+++ b/examples/3-cross-compiling/flake.nix
@@ -49,7 +49,7 @@
           # nixpkgs, set this target
           # target = "aarch64-unknown-linux-gnu";
           # target = "x86_64-unknown-linux-musl";
-          # target = "wasm32-wasi";
+          target = "wasm32-wasi";
         };
 
       in rec {

--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -2,7 +2,7 @@
 rec {
   fetchCratesIo = { name, version, sha256 }: buildPackages.fetchurl {
     name = "${name}-${version}.tar.gz";
-    url = "https://crates.io/api/v1/crates/${name}/${version}/download";
+    url = "https://static.crates.io/crates/${name}/${name}-${version}.crate";
     inherit sha256;
   };
 


### PR DESCRIPTION
## Summary
- switch cargo2nix's crates.io fetch helper from the crates.io API download endpoint to static.crates.io
- mirror the nixpkgs fix from NixOS/nixpkgs#524985 for recent crates.io 403/rate-limit behavior
- updates CI actions so that they don't fail on forks
- Created upstream PR here: https://github.com/cargo2nix/cargo2nix/pull/409

## Context
CI SITL VM builds can fail while fetching crate tarballs, for example:

```
https://crates.io/api/v1/crates/adler2/2.0.1/download
curl: (22) The requested URL returned error: 403
```

The generated cargo2nix derivations use `fetchCratesIo`, so this avoids the API path and uses the canonical static crate tarball URL instead. The source remains content-addressed by sha256, so this should not change successful fetch output contents.

## Verification
- `nix-instantiate --parse overlay/lib/fetch.nix`
- `git diff --check`